### PR TITLE
Add YARN as a resource / job manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ cdr/cdm/jupyter/
 build
 /.project
 /.pydevproject*
+/.pytest_cache/
+/.settings/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN cp -r /gradle/${GRADLE_JARS_DIR}/* /opt/bitnami/spark/jars/
 
 RUN chown -R spark_user:spark /opt/bitnami
 
+# make an empty yarn conf dir to prevent spark from complaining
+RUN mkdir -p /opt/yarn/conf && chown -R spark_user:spark /opt/yarn
+ENV YARN_CONF_DIR=/opt/yarn/conf
+
 # install pipenv
 RUN pip3 install pipenv
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Python 3.11 must be installed on the system.
 ```
 pipenv sync --dev  # only the first time or when Pipfile.lock changes
 pipenv shell
-PYTHONPATH=. pytest test
+PYTHONPATH=src pytest test
 ```
 
 ## Racher Deployment

--- a/config/yarn-write-policy.json
+++ b/config/yarn-write-policy.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::yarn",
+        "arn:aws:s3:::yarn/*"
+      ]
+    },
+    {
+      "Effect": "Deny",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:ForceDeleteBucket",
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": [
+        "arn:aws:s3:::yarn",
+        "arn:aws:s3:::yarn/*"
+      ]
+    }
+  ]
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,29 @@ version: '3'
 
 services:
 
+  yarn-resourcemanager:
+    image: ghcr.io/kbase/cdm-prototype-yarn:pr-6
+    container_name: yarn-resourcemanager
+    ports:
+      - 8088:8088  # web ui
+    environment:
+      - YARN_MODE=resourcemanager
+      - MINIO_URL=http://minio:9002
+      - MINIO_ACCESS_KEY=yarnuser
+      - MINIO_SECRET_KEY=yarnpass
+
+  yarn-nodemanager:
+    image: ghcr.io/kbase/cdm-prototype-yarn:pr-6
+    container_name: yarn-nodemanager
+    ports:
+      - 8042:8042  # web ui
+    environment:
+      - YARN_MODE=nodemanager
+      - YARN_RESOURCEMANAGER_HOSTNAME=yarn-resourcemanager
+      - MINIO_URL=http://minio:9002
+      - MINIO_ACCESS_KEY=yarnuser
+      - MINIO_SECRET_KEY=yarnpass
+
   spark-master:
     build:
       context: .
@@ -90,21 +113,11 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    entrypoint: >
-      bash -c "
-      mc alias set minio http://minio:9002 minio minio123 &&
-      if ! mc ls minio/cdm-lake 2>/dev/null; then
-        mc mb minio/cdm-lake && echo 'Bucket cdm-lake created'
-      else
-        echo 'bucket cdm-lake already exists'
-      fi &&
-      mc admin user add minio minio-readonly minio123 &&
-      mc admin policy create minio cdm-lake-read-only-policy /config/cdm-lake-read-only-policy.json &&
-      mc admin policy attach minio cdm-lake-read-only-policy --user=minio-readonly &&
-      echo 'CDM Read-only user and policy set'
-      "
+    entrypoint: /scripts/minio_create_bucket_entrypoint.sh
     volumes:
       - ./config/cdm-lake-read-only-policy.json:/config/cdm-lake-read-only-policy.json
+      - ./config/yarn-write-policy.json:/config/yarn-write-policy.json
+      - ./scripts/minio_create_bucket_entrypoint.sh:/scripts/minio_create_bucket_entrypoint.sh
 
   dev_notebook:
     build:
@@ -118,11 +131,13 @@ services:
       - minio-create-bucket
     environment:
       - NOTEBOOK_PORT=4041
+      - YARN_RESOURCE_MANAGER_URL=http://yarn-resourcemanager:8032
       - SPARK_MASTER_URL=spark://spark-master:7077
       - SPARK_DRIVER_HOST=spark-dev-notebook
       - MINIO_URL=http://minio:9002
       - MINIO_ACCESS_KEY=minio
       - MINIO_SECRET_KEY=minio123
+      - S3_YARN_BUCKET=yarn
       - SPARK_MODE=notebook
       - MAX_EXECUTORS=4
       - POSTGRES_USER=hive
@@ -145,11 +160,13 @@ services:
       - minio-create-bucket
     environment:
       - NOTEBOOK_PORT=4042
+      - YARN_RESOURCE_MANAGER_URL=http://yarn-resourcemanager:8032
       - SPARK_MASTER_URL=spark://spark-master:7077
       - SPARK_DRIVER_HOST=spark-user-notebook
       - MINIO_URL=http://minio:9002
       - MINIO_ACCESS_KEY=minio-readonly
       - MINIO_SECRET_KEY=minio123
+      - S3_YARN_BUCKET=yarn
       - SPARK_MODE=notebook
       - MAX_EXECUTORS=4
       # TODO: create postgres user w/ only write access to the hive tables

--- a/scripts/minio_create_bucket_entrypoint.sh
+++ b/scripts/minio_create_bucket_entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+mc alias set minio http://minio:9002 minio minio123
+
+# make deltalake bucket
+if ! mc ls minio/cdm-lake 2>/dev/null; then
+  mc mb minio/cdm-lake && echo 'Bucket cdm-lake created'
+else
+  echo 'bucket cdm-lake already exists'
+fi
+
+# make yarn bucket
+if ! mc ls minio/yarn 2>/dev/null; then
+  mc mb minio/yarn && echo 'Bucket yarn created'
+else
+  echo 'bucket yarn already exists'
+fi
+
+# create policies
+mc admin policy create minio yarn-write-policy /config/yarn-write-policy.json
+mc admin policy create minio cdm-lake-read-only-policy /config/cdm-lake-read-only-policy.json
+
+# make read only user for user notebook w/ yarn write privs
+mc admin user add minio minio-readonly minio123
+mc admin policy attach minio cdm-lake-read-only-policy --user=minio-readonly
+mc admin policy attach minio yarn-write-policy --user=minio-readonly
+echo 'CDM Read-only user and policy set'
+
+# make yarn user
+mc admin user add minio yarnuser yarnpass
+mc admin policy attach minio yarn-write-policy --user=yarnuser
+echo 'YARN user and policy set'

--- a/test/src/spark/utils_test.py
+++ b/test/src/spark/utils_test.py
@@ -46,7 +46,7 @@ def spark_session_non_local(mock_spark_master):
 
     with mock.patch.dict('os.environ', {"SPARK_MASTER_URL": spark_master_url,
                                         "SPARK_TIMEOUT_SECONDS": "2"}):
-        spark_session = get_spark_session("TestApp", local=False, delta_lake=False)
+        spark_session = get_spark_session("TestApp", local=False, delta_lake=False, yarn=False)
         print("Created non-local Spark session.")
         try:
             yield spark_session, port
@@ -98,7 +98,7 @@ def test_get_base_spark_conf():
     executor_cores = 3
 
     with mock.patch.dict('os.environ', {}):
-        result = _get_base_spark_conf(app_name, executor_cores)
+        result = _get_base_spark_conf(app_name, executor_cores, False)
         assert isinstance(result, SparkConf)
         assert result.get("spark.master") == expected_master_url
         assert result.get("spark.app.name") == expected_app_name
@@ -111,7 +111,7 @@ def test_get_base_spark_conf_with_env():
     executor_cores = 3
 
     with mock.patch.dict('os.environ', {"SPARK_MASTER_URL": custom_master_url}):
-        result = _get_base_spark_conf(app_name, executor_cores)
+        result = _get_base_spark_conf(app_name, executor_cores, False)
         assert isinstance(result, SparkConf)
         assert result.get("spark.master") == custom_master_url
         assert result.get("spark.app.name") == app_name


### PR DESCRIPTION
Uses YARN by default, but can use spark standalone optionally for now.

Tested by importing and querying the Fast Genomics Gene table.