### PR TITLE
Add MFA authentication requirement for JupyterHub login

### DIFF
--- a/src/jupyterhub_config/kb_jupyterhub_auth.py
+++ b/src/jupyterhub_config/kb_jupyterhub_auth.py
@@ -4,7 +4,7 @@ import os
 from jupyterhub.auth import Authenticator
 from traitlets import Unicode, List
 
-from service.kb_auth import KBaseAuth, MissingTokenError, AdminPermission
+from service.kb_auth import KBaseAuth, MissingTokenError, MFARequiredError, AdminPermission
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,10 @@ class KBaseAuthenticator(Authenticator):
 
         kb_auth = KBaseAuth(self.kbase_auth_url, self.auth_full_admin_roles)
         kb_user = await kb_auth.get_user(session_token)
+
+        # Check MFA requirement
+        if kb_user.mfa_authenticated is False or kb_user.mfa_authenticated is None:
+            raise MFARequiredError()
 
         logger.info(f"Authenticated user: {kb_user.user}")
         return {


### PR DESCRIPTION
## Summary
- Implement MFA authentication requirement for JupyterHub login
- Reject authentication when `mfaAuthenticated` is `false` or `null` from token endpoint
- Display clear error message directing users to enable MFA

## Changes
- **KBaseAuth**: Updated to call both `/me` and `/token` endpoints to get user data and MFA status
- **KBaseUser**: Added `mfa_authenticated` field to store MFA authentication status
- **KBaseAuthenticator**: Added MFA validation in `authenticate()` method
- **MFARequiredError**: New exception class for MFA requirement failures with user-friendly error message