### PR TITLE
[ CDM-245 ] Use auth2/token endpoint for token/MFA validation with expiration tracking

### DIFF
--- a/config/jupyterhub_config.py
+++ b/config/jupyterhub_config.py
@@ -17,7 +17,8 @@ from jupyterhub_config.custom_kube_spawner import CustomKubeSpawner
 from jupyterhub_config.kb_jupyterhub_auth import (
     KBaseAuthenticator,
     kbase_origin,
-    TokenRefreshHandler
+    TokenRefreshHandler,
+    MfaRequiredHandler
 )
 
 c = get_config()
@@ -48,9 +49,10 @@ if get_bool_env('USE_KBASE_AUTHENTICATOR'):
         'kbase_origin': f'https://{kbase_origin()}'
     }
 
-    # Add custom API handlers for token monitoring
+    # Add custom API handlers for token monitoring and MFA requirement
     c.JupyterHub.extra_handlers = [
         (r'/api/refresh-token', TokenRefreshHandler),
+        (r'/mfa-required', MfaRequiredHandler),
     ]
 else:
     # Set the authenticator class to nativeauthenticator

--- a/templates/login.html
+++ b/templates/login.html
@@ -122,7 +122,7 @@
     function checkKBaseCookie() {
       const tokenCookie = getCookie('kbase_session');
       if (!tokenCookie) return Promise.resolve(null);
-      return fetch(enviromentOrigin + '/services/auth/api/V2/me', {
+      return fetch(enviromentOrigin + '/services/auth/api/V2/token', {
         headers: {
           Authorization: tokenCookie,
         },

--- a/templates/mfa-required.html
+++ b/templates/mfa-required.html
@@ -1,0 +1,48 @@
+{% extends "page.html" %}
+
+{% block main %}
+<div id="mfa-main" class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <div class="text-center">
+            <h1>Multi-Factor Authentication Required</h1>
+            <div style="margin: 20px 0;">
+              <i class="fa fa-shield" style="font-size: 4em; color: #f0ad4e;"></i>
+            </div>
+            <p class="lead">
+              Access to JupyterHub requires multi-factor authentication (MFA) to be enabled and used during login.
+            </p>
+            
+            {% if mfa_status %}
+            <div class="alert alert-warning">
+              <strong>Current MFA Status:</strong> {{ mfa_status }}
+            </div>
+            {% endif %}
+            
+            <div class="alert alert-info">
+              <h4>To access JupyterHub:</h4>
+              <ol class="text-left">
+                <li>Log out of your current KBase session</li>
+                <li>Enable multi-factor authentication in your KBase account settings</li>
+                <li>Log back into KBase using MFA (typically via ORCID with 2FA enabled)</li>
+                <li>Return to JupyterHub</li>
+              </ol>
+            </div>
+            
+            <div style="margin-top: 30px;">
+              <a href="{{ kbase_origin }}/logout" class="btn btn-warning btn-lg">
+                Log Out of KBase
+              </a>
+              <a href="{{ kbase_origin }}/account" class="btn btn-primary btn-lg" style="margin-left: 10px;">
+                Account Settings
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock main %}


### PR DESCRIPTION
Implements MFA requirement validation for JupyterHub access.

## Changes
- Switch from auth2/me to auth2/token endpoint
- Enforce mfa_status == 'USED' for authentication 
- Add /mfa-required page for non-compliant users
- Configure 2-minute token refresh with MFA validation
- Store token expiration and MFA status in auth_state